### PR TITLE
update to use @joystream/types v0.12.0 - nicaea release

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "Joystream contributors",
   "license": "GPL-3.0-only",
   "dependencies": {
-    "@joystream/types": "^0.10.0",
+    "@joystream/types": "^0.12.0",
     "@polkadot/api": "^0.96.1",
     "@polkadot/keyring": "^1.7.0-beta.5",
     "@polkadot/types": "^0.96.1",

--- a/src/cli/create.ts
+++ b/src/cli/create.ts
@@ -6,7 +6,7 @@ import { CreateClassInputType,
   PropertyName, PropertyInputType, PropertyInputByClassNameType, PropertyByNameMap,
   AddClassSchemaInputType, AddClassSchemaInputByClassNameType
  } from '../types'
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
+import ClassId from '@joystream/types/versioned-store/ClassId';
 
 export async function createClassJson(name:string, description:string, sub: Substrate): Promise<CreateClassInputType> {
   const classJson: CreateClassInputType = 

--- a/src/cli/gets.ts
+++ b/src/cli/gets.ts
@@ -1,7 +1,7 @@
 import { Substrate } from './substrate';
 import { prettyClass, prettyEntity } from '../cli/printers';
 import { checkForDuplicateExistingClassNames } from '../cli/checks';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
+import ClassId from '@joystream/types/versioned-store/ClassId';
 import { ClassIdInputType, ClassIdandName, ClassIdToNameMap, ClassNameToIdMap, ClassIdToNameAndSchemasMap } from '../types/ClassIdType';
 import BN from 'bn.js';
 import { PropertyByNameMap, EntityIdInputType } from '../types';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -56,10 +56,10 @@ import {
  } from './transform'
 */
 import { bool, u32, Option } from '@polkadot/types';
-import { CredentialSet, Credential } from '@joystream/types/lib/versioned-store/permissions/credentials';
-import ClassPermissions from '@joystream/types/lib/versioned-store/permissions/ClassPermissions';
-import EntityPermissions from '@joystream/types/lib/versioned-store/permissions/EntityPermissions';
-import { ReferenceConstraint, NoConstraint } from '@joystream/types/lib/versioned-store/permissions/reference-constraint';
+import { CredentialSet, Credential } from '@joystream/types/common';
+import ClassPermissions from '@joystream/types/versioned-store/permissions/ClassPermissions';
+import EntityPermissions from '@joystream/types/versioned-store/permissions/EntityPermissions';
+import { ReferenceConstraint, NoConstraint } from '@joystream/types/versioned-store/permissions/reference-constraint';
 
 import { CreateClassInputType
   /*,

--- a/src/cli/permissions.ts
+++ b/src/cli/permissions.ts
@@ -1,9 +1,9 @@
 
-import ClassPermissions from '@joystream/types/lib/versioned-store/permissions/ClassPermissions';
-import EntityPermissions from '@joystream/types/lib/versioned-store/permissions/EntityPermissions';
-import { CredentialSet } from '@joystream/types/lib/versioned-store/permissions/credentials';
+import ClassPermissions from '@joystream/types/versioned-store/permissions/ClassPermissions';
+import EntityPermissions from '@joystream/types/versioned-store/permissions/EntityPermissions';
+import { CredentialSet } from '@joystream/types/common';
 import { bool, u32 } from '@polkadot/types';
-import { ReferenceConstraint, /* NoConstraint */ } from '@joystream/types/lib/versioned-store/permissions/reference-constraint';
+import { ReferenceConstraint, /* NoConstraint */ } from '@joystream/types/versioned-store/permissions/reference-constraint';
 
 const CREDENTIAL_ONE = new u32(1);
 

--- a/src/cli/printers.ts
+++ b/src/cli/printers.ts
@@ -1,4 +1,4 @@
-import { Class, VecProperty, Entity } from '@joystream/types/lib/versioned-store';
+import { Class, VecProperty, Entity } from '@joystream/types/versioned-store';
 
 // tslint:disable-next-line:import-name
 import BN from 'bn.js';

--- a/src/cli/questions.ts
+++ b/src/cli/questions.ts
@@ -1,4 +1,4 @@
-//import PropertyTypeName from '@joystream/types/lib/versioned-store/PropertyTypeName';
+//import { PropertyTypeName } from '@joystream/types/versioned-store/PropertyTypeName';
 /*
 function stringToArray(input:string) {
   const array:string[] = []

--- a/src/cli/substrate.ts
+++ b/src/cli/substrate.ts
@@ -8,13 +8,13 @@ import { KeypairType } from '@polkadot/util-crypto/types';
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { RpcEndpoints, greenItem } from './utils';
 import { registerJoystreamTypes } from '@joystream/types';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
-import { Class, Entity } from '@joystream/types/lib/versioned-store';
-import PropertyTypeName from '@joystream/types/lib/versioned-store/PropertyTypeName';
+import ClassId from '@joystream/types/versioned-store/ClassId';
+import EntityId from '@joystream/types/versioned-store/EntityId';
+import { Class, Entity } from '@joystream/types/versioned-store';
+import { PropertyTypeName } from '@joystream/types/versioned-store/PropertyTypeName';
 import { EventData } from '@polkadot/types/primitive/Generic/Event';
-import ClassPermissions from '@joystream/types/lib/versioned-store/permissions/ClassPermissions'
-import { Credential } from '@joystream/types/lib/versioned-store/permissions/credentials';
+import ClassPermissions from '@joystream/types/versioned-store/permissions/ClassPermissions'
+import { Credential } from '@joystream/types/common';
 import { Option, u16 } from '@polkadot/types';
 
 import {

--- a/src/cli/transform.ts
+++ b/src/cli/transform.ts
@@ -1,5 +1,5 @@
 import { Substrate } from './substrate';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
+import ClassId from '@joystream/types/versioned-store/ClassId';
 import { ClassIdInputType,
   AddClassSchemaInputType, AddClassSchemaInputByClassNameType,
   PropertyInputType,

--- a/src/examples/substrate-playground.ts
+++ b/src/examples/substrate-playground.ts
@@ -1,18 +1,18 @@
 import { Substrate } from "../cli/substrate";
 import { arrayToOneLineString, prettyClass, prettyEntity } from '../cli/printers';
 import { AddClassSchemaInputType } from '../types/AddClassSchemaTypes';
-import ClassPermissions from '@joystream/types/lib/versioned-store/permissions/ClassPermissions';
-import EntityPermissions from '@joystream/types/lib/versioned-store/permissions/EntityPermissions';
-import { CredentialSet, Credential } from '@joystream/types/lib/versioned-store/permissions/credentials';
+import ClassPermissions from '@joystream/types/versioned-store/permissions/ClassPermissions';
+import EntityPermissions from '@joystream/types/versioned-store/permissions/EntityPermissions';
+import { CredentialSet, Credential } from '@joystream/types/common';
 import { bool, u64, u32, u16, Option, Vec } from '@polkadot/types';
-import { ReferenceConstraint } from '@joystream/types/lib/versioned-store/permissions/reference-constraint';
-import { OperationType} from '@joystream/types/lib/versioned-store/permissions/batching/operation-types';
-import { Operation } from '@joystream/types/lib/versioned-store/permissions/batching/';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
-import { ParametrizedEntity } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-entity';
-import { ParametrizedPropertyValue } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-property-value';
-import { Text as TextValue, TextVec as TextVecValue } from '@joystream/types/lib/versioned-store/PropertyValue';
-import ParametrizedClassPropertyValue from '@joystream/types/lib/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
+import { ReferenceConstraint } from '@joystream/types/versioned-store/permissions/reference-constraint';
+import { OperationType} from '@joystream/types/versioned-store/permissions/batching/operation-types';
+import { Operation } from '@joystream/types/versioned-store/permissions/batching/';
+import ClassId from '@joystream/types/versioned-store/ClassId';
+import { ParametrizedEntity } from '@joystream/types/versioned-store/permissions/batching/parametrized-entity';
+import { ParametrizedPropertyValue } from '@joystream/types/versioned-store/permissions/batching/parametrized-property-value';
+import { Text as TextValue, TextVec as TextVecValue } from '@joystream/types/versioned-store/PropertyValue';
+import ParametrizedClassPropertyValue from '@joystream/types/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
 
 const CURRENT_LEAD_CREDENTIAL = new u64(0);
 

--- a/src/scripts/add-schema-support-to-entity-from-json-schema-batch.ts
+++ b/src/scripts/add-schema-support-to-entity-from-json-schema-batch.ts
@@ -1,22 +1,22 @@
 import { Substrate } from "../cli/substrate";
 import { prettyEntity } from '../cli/printers';
 import { checkForDuplicateExistingClassNames } from "../cli/checks";
-import { Credential } from '@joystream/types/lib/versioned-store/permissions/credentials';
+import { Credential } from '@joystream/types/common';
 import { bool, Option, Vec } from '@polkadot/types';
-import { OperationType} from '@joystream/types/lib/versioned-store/permissions/batching/operation-types';
-import { Operation } from '@joystream/types/lib/versioned-store/permissions/batching/';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
-import { ParametrizedEntity } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-entity';
-import { ParametrizedPropertyValue } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-property-value';
-import ParametrizedClassPropertyValue from '@joystream/types/lib/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
+import { OperationType} from '@joystream/types/versioned-store/permissions/batching/operation-types';
+import { Operation } from '@joystream/types/versioned-store/permissions/batching/';
+import ClassId from '@joystream/types/versioned-store/ClassId';
+import { ParametrizedEntity } from '@joystream/types/versioned-store/permissions/batching/parametrized-entity';
+import { ParametrizedPropertyValue } from '@joystream/types/versioned-store/permissions/batching/parametrized-property-value';
+import ParametrizedClassPropertyValue from '@joystream/types/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
 import { transformPropertyValueToEnum } from '../transformPropertyValueToEnumValue'
 import { transformAddSchemaSupportToEntity } from '../transformAddSchemaSupportToEntity'
 import { PropertyByNameMap, AddSchemaSupportToEntityInputType, AddSchemaSupportToEntityOutputType, PropertyValueInputType } from '../types';
-import { PropertyValueEnumValue } from '@joystream/types/lib/versioned-store/PropertyValue';
+import { PropertyValueEnumValue } from '@joystream/types/versioned-store/PropertyValue';
 
 import entityJsons = require('../inputs/entity-values/add-new-schema-support-json-schemas/index.js');
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
-import PropertyTypeName from '@joystream/types/lib/versioned-store/PropertyTypeName';
+import EntityId from '@joystream/types/versioned-store/EntityId';
+import { PropertyTypeName } from '@joystream/types/versioned-store/PropertyTypeName';
 
 import {
   CURRENT_LEAD_CREDENTIAL

--- a/src/scripts/create-and-add-schema-support-to-entity-from-json-schema-batch.ts
+++ b/src/scripts/create-and-add-schema-support-to-entity-from-json-schema-batch.ts
@@ -1,18 +1,18 @@
 import { Substrate } from "../cli/substrate";
 import { prettyClass, prettyEntity } from '../cli/printers';
 import { checkForDuplicateExistingClassNames } from "../cli/checks";
-import { Credential } from '@joystream/types/lib/versioned-store/permissions/credentials';
+import { Credential } from '@joystream/types/common';
 import { bool, u32, Option, Vec } from '@polkadot/types';
-import { OperationType} from '@joystream/types/lib/versioned-store/permissions/batching/operation-types';
-import { Operation } from '@joystream/types/lib/versioned-store/permissions/batching/';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
-import { ParametrizedEntity } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-entity';
-import { ParametrizedPropertyValue } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-property-value';
-import ParametrizedClassPropertyValue from '@joystream/types/lib/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
+import { OperationType} from '@joystream/types/versioned-store/permissions/batching/operation-types';
+import { Operation } from '@joystream/types/versioned-store/permissions/batching/';
+import ClassId from '@joystream/types/versioned-store/ClassId';
+import { ParametrizedEntity } from '@joystream/types/versioned-store/permissions/batching/parametrized-entity';
+import { ParametrizedPropertyValue } from '@joystream/types/versioned-store/permissions/batching/parametrized-property-value';
+import ParametrizedClassPropertyValue from '@joystream/types/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
 import { transformPropertyValueToEnum } from '../transformPropertyValueToEnumValue'
 import { transformAddSchemaSupportToEntity } from '../transformAddSchemaSupportToEntity'
 import { PropertyByNameMap, AddSchemaSupportToEntityInputType, AddSchemaSupportToEntityOutputType } from '../types';
-import { PropertyValueEnumValue } from '@joystream/types/lib/versioned-store/PropertyValue';
+import { PropertyValueEnumValue } from '@joystream/types/versioned-store/PropertyValue';
 
 import entityJsons = require('../inputs/entity-values/add-schema-support-json-schemas/index.js');
 

--- a/src/scripts/create-class-add-schema-from-json-schema-by-internal-name-refs.ts
+++ b/src/scripts/create-class-add-schema-from-json-schema-by-internal-name-refs.ts
@@ -3,13 +3,13 @@ import { transformClassSchemaByNameToId } from "../cli/transform";
 import { prettyClass } from '../cli/printers';
 import { checkUniqueClassNamesFromJson } from "../cli/checks";
 import { CreateClassInputType, AddClassSchemaInputByClassNameType, ClassSchemaInputByClassNameType } from '../types';
-import ClassPermissions from '@joystream/types/lib/versioned-store/permissions/ClassPermissions';
-import EntityPermissions from '@joystream/types/lib/versioned-store/permissions/EntityPermissions';
-import { CredentialSet, Credential } from '@joystream/types/lib/versioned-store/permissions/credentials';
+import ClassPermissions from '@joystream/types/versioned-store/permissions/ClassPermissions';
+import EntityPermissions from '@joystream/types/versioned-store/permissions/EntityPermissions';
+import { CredentialSet, Credential } from '@joystream/types/common';
 import { bool, u32, Option } from '@polkadot/types';
-import { ReferenceConstraint } from '@joystream/types/lib/versioned-store/permissions/reference-constraint';
+import { ReferenceConstraint } from '@joystream/types/versioned-store/permissions/reference-constraint';
 import { transformAddClassSchema } from '../transformAddClassSchema'
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
+import ClassId from '@joystream/types/versioned-store/ClassId';
 import { validateCreateClass } from '../validate'
 
 import {

--- a/src/scripts/update-entity-properties-from-json-schema-batch.ts
+++ b/src/scripts/update-entity-properties-from-json-schema-batch.ts
@@ -1,18 +1,18 @@
 import { Substrate } from "../cli/substrate";
 import { prettyEntity } from '../cli/printers';
 import { checkForDuplicateExistingClassNames } from "../cli/checks";
-import { Credential } from '@joystream/types/lib/versioned-store/permissions/credentials';
+import { Credential } from '@joystream/types/common';
 import { bool, u32, Option, Vec } from '@polkadot/types';
-import { OperationType} from '@joystream/types/lib/versioned-store/permissions/batching/operation-types';
-import { Operation } from '@joystream/types/lib/versioned-store/permissions/batching/';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
-import { ParametrizedEntity } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-entity';
-import { ParametrizedPropertyValue } from '@joystream/types/lib/versioned-store/permissions/batching/parametrized-property-value';
-import ParametrizedClassPropertyValue from '@joystream/types/lib/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
+import { OperationType} from '@joystream/types/versioned-store/permissions/batching/operation-types';
+import { Operation } from '@joystream/types/versioned-store/permissions/batching/';
+import ClassId from '@joystream/types/versioned-store/ClassId';
+import EntityId from '@joystream/types/versioned-store/EntityId';
+import { ParametrizedEntity } from '@joystream/types/versioned-store/permissions/batching/parametrized-entity';
+import { ParametrizedPropertyValue } from '@joystream/types/versioned-store/permissions/batching/parametrized-property-value';
+import ParametrizedClassPropertyValue from '@joystream/types/versioned-store/permissions/batching/ParametrizedClassPropertyValue';
 import { transformPropertyValueToEnum } from '../transformPropertyValueToEnumValue'
 import { PropertyByNameMap, UpdateEntityPropertyValuesInputType } from '../types';
-import { PropertyValueEnumValue } from '@joystream/types/lib/versioned-store/PropertyValue';
+import { PropertyValueEnumValue } from '@joystream/types/versioned-store/PropertyValue';
 
 import entityJsons = require('../inputs/entity-values/update-entities/index.js');
 

--- a/src/transformAddClassSchema.ts
+++ b/src/transformAddClassSchema.ts
@@ -1,7 +1,7 @@
 import { AddClassSchemaInputType, AddClassSchemaOutputType } from './types/AddClassSchemaTypes';
 import { validateAddClassSchema } from './validate';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
-import { Property, VecU16, VecProperty } from '@joystream/types/lib/versioned-store';
+import ClassId from '@joystream/types/versioned-store/ClassId';
+import { Property, VecU16, VecProperty } from '@joystream/types/versioned-store';
 import { u16, bool as Bool, Text } from '@polkadot/types';
 import { TransformationResult, wrapValidationErrors } from './transform';
 import { PropertyByNameMap } from './types/PropertyTypes';

--- a/src/transformAddSchemaSupportToEntity.ts
+++ b/src/transformAddSchemaSupportToEntity.ts
@@ -1,8 +1,8 @@
 import { validateAddSchemaSupportToEntity } from './validate';
-import { ClassPropertyValue, VecClassPropertyValue } from '@joystream/types/lib/versioned-store';
+import { ClassPropertyValue, VecClassPropertyValue } from '@joystream/types/versioned-store';
 import { u16 } from '@polkadot/types';
 import { AddSchemaSupportToEntityInputType, AddSchemaSupportToEntityOutputType } from './types/AddSchemaSupportToEntityTypes';
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
+import EntityId from '@joystream/types/versioned-store/EntityId';
 import { TransformationResult, wrapValidationErrors } from './transform';
 import { PropertyByNameMap } from './types/PropertyTypes';
 import { transformPropertyValue } from './transformPropertyValue';

--- a/src/transformAddSchemaSupportToEntityForBatching.ts
+++ b/src/transformAddSchemaSupportToEntityForBatching.ts
@@ -1,8 +1,8 @@
 import { validateAddSchemaSupportToEntity } from './validate';
-import { ClassPropertyValue, VecClassPropertyValue } from '@joystream/types/lib/versioned-store';
+import { ClassPropertyValue, VecClassPropertyValue } from '@joystream/types/versioned-store';
 import { u16 } from '@polkadot/types';
 import { AddSchemaSupportToEntityInputType, AddSchemaSupportToEntityOutputType } from './types/AddSchemaSupportToEntityTypes';
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
+import EntityId from '@joystream/types/versioned-store/EntityId';
 import { TransformationResult, wrapValidationErrors } from './transform';
 import { PropertyByNameMap } from './types/PropertyTypes';
 import { transformPropertyValue } from './transformPropertyValue';

--- a/src/transformCreateEntity.ts
+++ b/src/transformCreateEntity.ts
@@ -1,7 +1,7 @@
 import { validateCreateEntity } from './validate';
 import { CreateEntityInputType, CreateEntityOutputType } from './types/CreateEntityTypes';
 import { TransformationResult, wrapValidationErrors } from './transform';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
+import ClassId from '@joystream/types/versioned-store/ClassId';
 
 export function transformCreateEntity(
   inputData: CreateEntityInputType

--- a/src/transformPropertyType.ts
+++ b/src/transformPropertyType.ts
@@ -1,5 +1,5 @@
-import PropertyType from '@joystream/types/lib/versioned-store/PropertyType';
-import * as PT from '@joystream/types/lib/versioned-store/PropertyType';
+import PropertyType from '@joystream/types/versioned-store/PropertyType';
+import * as PT from '@joystream/types/versioned-store/PropertyType';
 import { TransformationResult } from './transform';
 import { PropertyInputType } from './types/PropertyTypes';
 

--- a/src/transformPropertyValue.ts
+++ b/src/transformPropertyValue.ts
@@ -1,9 +1,9 @@
-import * as PV from '@joystream/types/lib/versioned-store/PropertyValue';
-import { PropertyValue } from '@joystream/types/lib/versioned-store/PropertyValue';
+import * as PV from '@joystream/types/versioned-store/PropertyValue';
+import { PropertyValue } from '@joystream/types/versioned-store/PropertyValue';
 import { EntityIdInputType } from './types/EntityIdType';
 import { TransformationResult } from './transform';
 import { PropertyValueInputType } from './types/PropertyTypes';
-import PropertyTypeName from '@joystream/types/lib/versioned-store/PropertyTypeName';
+import { PropertyTypeName } from '@joystream/types/versioned-store/PropertyTypeName';
 
 export function transformPropertyValue(propType: PropertyTypeName, value: PropertyValueInputType): TransformationResult<string, PropertyValue> {
 

--- a/src/transformPropertyValueToEnumValue.ts
+++ b/src/transformPropertyValueToEnumValue.ts
@@ -1,7 +1,7 @@
-import * as PV from '@joystream/types/lib/versioned-store/PropertyValue';
+import * as PV from '@joystream/types/versioned-store/PropertyValue';
 import { EntityIdInputType } from './types/EntityIdType';
 import { PropertyValueInputType } from './types/PropertyTypes';
-import PropertyTypeName from '@joystream/types/lib/versioned-store/PropertyTypeName';
+import { PropertyTypeName } from '@joystream/types/versioned-store/PropertyTypeName';
 
 export function transformPropertyValueToEnum(propType: PropertyTypeName, value: PropertyValueInputType): PV.PropertyValueEnumValue {
 

--- a/src/transformUpdateEntityPropertyValues.ts
+++ b/src/transformUpdateEntityPropertyValues.ts
@@ -1,8 +1,8 @@
 import { validateUpdateEntityPropertyValues } from './validate';
-import { ClassPropertyValue, VecClassPropertyValue } from '@joystream/types/lib/versioned-store';
+import { ClassPropertyValue, VecClassPropertyValue } from '@joystream/types/versioned-store';
 import { u16 } from '@polkadot/types';
 import { UpdateEntityPropertyValuesInputType, UpdateEntityPropertyValuesOutputType } from './types/UpdateEntityPropertyValuesTypes';
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
+import EntityId from '@joystream/types/versioned-store/EntityId';
 import { TransformationResult, wrapValidationErrors } from './transform';
 import { PropertyByNameMap } from './types/PropertyTypes';
 import { transformPropertyValue } from './transformPropertyValue';

--- a/src/types/AddClassSchemaTypes.ts
+++ b/src/types/AddClassSchemaTypes.ts
@@ -1,6 +1,6 @@
 import { ClassIdInputType } from './ClassIdType';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
-import { VecProperty, VecU16 } from '@joystream/types/lib/versioned-store';
+import ClassId from '@joystream/types/versioned-store/ClassId';
+import { VecProperty, VecU16 } from '@joystream/types/versioned-store';
 import { PropertyName, PropertyInputType, PropertyInputByClassNameType } from './PropertyTypes';
 
 export type AddClassSchemaInputType = {

--- a/src/types/AddSchemaSupportToEntityTypes.ts
+++ b/src/types/AddSchemaSupportToEntityTypes.ts
@@ -1,6 +1,6 @@
 import { u16 } from '@polkadot/types';
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
-import { VecClassPropertyValue } from '@joystream/types/lib/versioned-store';
+import EntityId from '@joystream/types/versioned-store/EntityId';
+import { VecClassPropertyValue } from '@joystream/types/versioned-store';
 import { PropertyNameAndValueInputType } from './PropertyTypes';
 import { EntityIdInputType } from './EntityIdType';
 

--- a/src/types/ClassIdType.ts
+++ b/src/types/ClassIdType.ts
@@ -1,4 +1,4 @@
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
+import ClassId from '@joystream/types/versioned-store/ClassId';
 import { Text } from '@polkadot/types';
 
 export type ClassIdInputType = ClassId | number;

--- a/src/types/CreateEntityTypes.ts
+++ b/src/types/CreateEntityTypes.ts
@@ -1,5 +1,5 @@
 import { ClassIdInputType } from './ClassIdType';
-import ClassId from '@joystream/types/lib/versioned-store/ClassId';
+import ClassId from '@joystream/types/versioned-store/ClassId';
 
 export type CreateEntityInputType = {
   classId: ClassIdInputType

--- a/src/types/EntityIdType.ts
+++ b/src/types/EntityIdType.ts
@@ -1,3 +1,3 @@
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
+import EntityId from '@joystream/types/versioned-store/EntityId';
 
 export type EntityIdInputType = EntityId | number;

--- a/src/types/PropertyTypes.ts
+++ b/src/types/PropertyTypes.ts
@@ -1,6 +1,6 @@
 import { EntityIdInputType } from './EntityIdType';
 import { ClassIdInputType } from './ClassIdType';
-import PropertyTypeName from '@joystream/types/lib/versioned-store/PropertyTypeName';
+import { PropertyTypeName } from '@joystream/types/versioned-store/PropertyTypeName';
 
 export type PropertyName = string;
 

--- a/src/types/UpdateEntityPropertyValuesTypes.ts
+++ b/src/types/UpdateEntityPropertyValuesTypes.ts
@@ -1,5 +1,5 @@
-import EntityId from '@joystream/types/lib/versioned-store/EntityId';
-import { VecClassPropertyValue } from '@joystream/types/lib/versioned-store';
+import EntityId from '@joystream/types/versioned-store/EntityId';
+import { VecClassPropertyValue } from '@joystream/types/versioned-store';
 import { EntityIdInputType } from './EntityIdType';
 import { PropertyNameAndValueInputType } from './PropertyTypes';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,15 +294,18 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@joystream/types@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.10.0.tgz#7e98ef221410b26a7d952cfc3d1c03d28395ad69"
-  integrity sha512-RDZizqGKWGYpLR5PnUWM4aGa7InpWNh2Txlr7Al3ROFYOHoyQf62/omPfEz29F6scwlFxysOdmEfQaLeVRaUxA==
+"@joystream/types@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.12.0.tgz#4033967ae2ac111f894fb4100e414f7cdbe95611"
+  integrity sha512-pHHYTbIa6V1C4k9aj+M6Fkwa2I2Br+4x7cuvREmrVh21GHjGuzoIwB74MfqFajdSTDQDZbjdixcYDES6uo3sUg==
   dependencies:
+    "@polkadot/keyring" "^1.7.0-beta.5"
     "@polkadot/types" "^0.96.1"
+    "@types/lodash" "^4.14.157"
     "@types/vfile" "^4.0.0"
     ajv "^6.11.0"
     lodash "^4.17.15"
+    moment "^2.24.0"
 
 "@polkadot/api-derive@^0.96.1":
   version "0.96.1"
@@ -522,6 +525,11 @@
   integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
   dependencies:
     jest-diff "^24.3.0"
+
+"@types/lodash@^4.14.157":
+  version "4.14.158"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.158.tgz#b38ea8b6fe799acd076d7a8d7ab71c26ef77f785"
+  integrity sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==
 
 "@types/memoizee@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Basic updates to use latest types library for nicaea:

`yarn && yarn build && yarn build-inputs` builds successfully.

Then ran scripts:

```
node build/src/scripts/create-class-add-schema-from-json-schema-by-internal-name-refs.js ....
node build/src/scripts/create-and-add-schema-support-to-entity-from-json-schema-batch.js ...
```

against a nicaea dev chain worked as expected.